### PR TITLE
Add ZeppOS hello world example for Amazfit Active 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# amazfit-hello-world
-# amazfit-test-1
+# Amazfit Active 2 Hello World sample
+
+This repository contains a minimal ZeppOS mini program that displays a "Hello, Active 2!" message on Amazfit Active 2 watches.
+
+See [`hello-active2/README.md`](hello-active2/README.md) for setup instructions, build steps, and project details.

--- a/hello-active2/README.md
+++ b/hello-active2/README.md
@@ -1,0 +1,59 @@
+# Hello Active 2 ZeppOS sample
+
+This folder contains a minimal ZeppOS mini program that renders a centered "Hello, Active 2!" message on devices such as the Amazfit Active 2.
+
+The layout is built at runtime in `pages/index/index.js` using the `hmUI.createWidget` API so that it works on round or rectangular displays.
+
+## Project structure
+
+```
+hello-active2/
+├── app.json              # Mini program manifest with metadata and page list
+├── app.js                # Application lifecycle entry point
+├── assets/
+│   └── README.txt        # Instructions for providing an icon (app.png)
+├── i18n/
+│   └── en-US.po          # Localized strings used by gettext()
+└── pages/
+    └── index/
+        ├── index.js      # Page logic that renders the hello world text
+        └── index.page    # Optional declarative page configuration (background)
+```
+
+## Prerequisites
+
+1. Install the [ZeppOS Developer IDE](https://docs.zepp.com/docs/tools/zeppos-ide/) or the CLI (`@zeppos/zeus-cli`).
+2. Set up a developer certificate and pair your Amazfit Active 2 with the Zepp developer tools following the instructions in the ZeppOS documentation.
+
+## Running on device or emulator
+
+### Using the ZeppOS IDE
+
+1. Open the ZeppOS IDE and choose **Import Project**.
+2. Select the `hello-active2` directory.
+3. Provide an icon named `app.png` (192×192) inside `hello-active2/assets/` if you have not already.
+4. Press **Build & Install** to deploy the app to the watch or to the IDE emulator.
+
+### Using the CLI
+
+If you prefer the CLI, the workflow is similar:
+
+```bash
+npm install -g @zeppos/zeus-cli
+cd hello-active2
+zeus clean
+zeus build
+zeus install --device active_2
+```
+
+The `zeus install` step assumes that the Active 2 has been paired and authorized via the Zepp developer tools.
+
+## Customizing
+
+* To change the text, update the `msgstr` in `i18n/en-US.po`.
+* Adjust positioning or font settings by editing the widget configuration inside `pages/index/index.js`.
+* Add more pages by listing them in the `module.pages` array inside `app.json` and creating a corresponding folder under `pages/`.
+
+## Packaging for release
+
+When you are ready to share the app, run `zeus package`. The command produces an `.app` bundle that can be uploaded to the ZeppOS developer console for distribution or sideloaded onto the watch.

--- a/hello-active2/app.js
+++ b/hello-active2/app.js
@@ -1,0 +1,9 @@
+App({
+  globalData: {},
+  onCreate(options) {
+    console.log("Hello Active 2 app created", options);
+  },
+  onDestroy(options) {
+    console.log("Hello Active 2 app destroyed", options);
+  }
+});

--- a/hello-active2/app.json
+++ b/hello-active2/app.json
@@ -1,0 +1,35 @@
+{
+  "app": {
+    "appId": "com.example.helloactive2",
+    "appName": {
+      "en-US": "Hello Active 2"
+    },
+    "version": {
+      "code": 1,
+      "name": "1.0.0"
+    },
+    "icon": "assets/app.png",
+    "description": {
+      "en-US": "Minimal Zepp OS hello world sample for Amazfit Active 2."
+    }
+  },
+  "module": {
+    "pages": [
+      "pages/index/index"
+    ]
+  },
+  "i18n": [
+    "en-US"
+  ],
+  "runtime": {
+    "minPlatformVersion": "2.0"
+  },
+  "targets": [
+    {
+      "platform": "watch",
+      "devices": [
+        "active_2"
+      ]
+    }
+  ]
+}

--- a/hello-active2/assets/README.txt
+++ b/hello-active2/assets/README.txt
@@ -1,0 +1,1 @@
+Place a 192x192 PNG named app.png in this directory before packaging the project.

--- a/hello-active2/i18n/en-US.po
+++ b/hello-active2/i18n/en-US.po
@@ -1,0 +1,9 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: hello-active2 1.0.0\n"
+"Language: en-US\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "hello_message"
+msgstr "Hello, Active 2!"

--- a/hello-active2/pages/index/index.js
+++ b/hello-active2/pages/index/index.js
@@ -1,0 +1,18 @@
+import { gettext } from "i18n";
+
+Page({
+  build() {
+    hmUI.createWidget(hmUI.widget.TEXT, {
+      x: 0,
+      y: 160,
+      w: 480,
+      h: 80,
+      color: 0xffffff,
+      text_size: 36,
+      align_h: hmUI.align.CENTER_H,
+      align_v: hmUI.align.CENTER_V,
+      text_style: hmUI.text_style.WRAP,
+      text: gettext("hello_message")
+    });
+  }
+});

--- a/hello-active2/pages/index/index.page
+++ b/hello-active2/pages/index/index.page
@@ -1,0 +1,5 @@
+{
+  "background": {
+    "color": 0
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal ZeppOS manifest, entry point, and page logic that renders a "Hello, Active 2!" message
- document the project structure along with IDE/CLI steps for building, installing, and customizing the sample

## Testing
- not run (Zepp OS tooling is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0fb2406f883299c89facc280d81da